### PR TITLE
Fix font loading and API error handling

### DIFF
--- a/src/app/api/geocode/route.ts
+++ b/src/app/api/geocode/route.ts
@@ -65,8 +65,9 @@ export async function GET(request: Request) {
     // Suggestion 3: Log and include error details
     // This helps debug issues by logging the error and sending its message to the client.
     console.error('Geocode fetch error:', error);
+    const details = error instanceof Error ? error.message : String(error);
     return NextResponse.json(
-      { message: 'Failed to fetch geocode data', details: error.message },
+      { message: 'Failed to fetch geocode data', details },
       { status: 500 }
     );
   }

--- a/src/app/api/onecall/route.ts
+++ b/src/app/api/onecall/route.ts
@@ -57,8 +57,9 @@ export async function GET(request: Request) {
     }
   } catch (error) {
     console.error('OneCall fetch error:', error);
+    const details = error instanceof Error ? error.message : String(error);
     return NextResponse.json(
-      { message: 'Failed to fetch alert data', details: error.message },
+      { message: 'Failed to fetch alert data', details },
       { status: 500 }
     );
   }

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -10,8 +10,9 @@
 @theme inline {
   --color-background: var(--background);
   --color-foreground: var(--foreground);
-  --font-sans: var(--font-geist-sans);
-  --font-mono: var(--font-geist-mono);
+  /* Use system fonts to avoid external Google Font dependency */
+  --font-sans: system-ui, sans-serif;
+  --font-mono: ui-monospace, monospace;
 }
 
 @media (prefers-color-scheme: dark) {

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,16 +1,5 @@
 import type { Metadata } from "next";
-import { Geist, Geist_Mono } from "next/font/google";
 import "./globals.css";
-
-const geistSans = Geist({
-  variable: "--font-geist-sans",
-  subsets: ["latin"],
-});
-
-const geistMono = Geist_Mono({
-  variable: "--font-geist-mono",
-  subsets: ["latin"],
-});
 
 export const metadata: Metadata = {
   title: "ALWeather",
@@ -24,11 +13,7 @@ export default function RootLayout({
 }>) {
   return (
     <html lang="en">
-      <body
-        className={`${geistSans.variable} ${geistMono.variable} antialiased`}
-      >
-        {children}
-      </body>
+      <body className="antialiased">{children}</body>
     </html>
   );
 }

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -113,8 +113,9 @@ export default function Home() {
         const alertsData = await alertsRes.json();
         setAlerts(alertsData.alerts || []);
       }
-    } catch (err: any) {
-      setError(err.message || 'An error occurred while fetching weather data');
+    } catch (err: unknown) {
+      const message = err instanceof Error ? err.message : 'An error occurred while fetching weather data';
+      setError(message);
     } finally {
       setLoading(false);
     }
@@ -154,21 +155,25 @@ export default function Home() {
   // Locate once on mount
   useEffect(() => {
     locateMe();
-  }, []);
+  }, []); // eslint-disable-line react-hooks/exhaustive-deps
 
   // On unit change, refetch Open-Meteo + city weather (no geolocation prompt)
   useEffect(() => {
     if (coords) fetchOpenMeteo(coords.lat, coords.lon);
     if (city) fetchWeather(city);
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [unit]);
+  }, [unit]); // eslint-disable-line react-hooks/exhaustive-deps
 
   // Animations
   const cardVariants = { hidden: { opacity: 0, y: 20 }, visible: { opacity: 1, y: 0, transition: { duration: 0.5 } } };
   const gridContainerVariants = { hidden: { opacity: 0 }, visible: { opacity: 1, transition: { staggerChildren: 0.12 } } };
   const gridItemVariants = {
     hidden: { opacity: 0, y: 18, scale: 0.98 },
-    visible: { opacity: 1, y: 0, scale: 1, transition: { type: 'spring', stiffness: 220, damping: 22 } },
+    visible: {
+      opacity: 1,
+      y: 0,
+      scale: 1,
+      transition: { type: 'spring' as const, stiffness: 220, damping: 22 },
+    },
   };
 
   // Format helpers


### PR DESCRIPTION
## Summary
- Remove Google font imports and rely on system fonts
- Improve API error handling for geocode and OneCall routes
- Correct framer-motion variant typing for build stability

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68994fe62b9c8321a9e456a9fe615392