### PR TITLE
Enable lint enforcement in build pipeline

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,20 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: 'npm'
+      - run: npm ci
+      - run: npm run lint
+      - run: npm run build

--- a/next.config.ts
+++ b/next.config.ts
@@ -1,10 +1,6 @@
 import type { NextConfig } from 'next';
 
 const nextConfig: NextConfig = {
-  eslint: {
-    // Allow production builds to complete even if there are ESLint errors.
-    ignoreDuringBuilds: true,
-  },
   images: {
     domains: ['openweathermap.org'], // Allow images from this domain
   },

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -556,8 +556,8 @@ export default function Page() {
         const data: WeatherData = await res.json();
         setWeatherData(data);
 
-      } catch (err: any) {
-        if (err.name !== 'AbortError') {
+      } catch (err: unknown) {
+        if (err instanceof Error && err.name !== 'AbortError') {
           setError(err.message);
         }
       } finally {
@@ -610,8 +610,9 @@ export default function Page() {
       setCoords(c);
       setError(null);
 
-    } catch (e: any) {
-      setError(e.message || "Search error");
+    } catch (e: unknown) {
+      const message = e instanceof Error ? e.message : "Search error";
+      setError(message);
     }
   }
   


### PR DESCRIPTION
## Summary
- remove `ignoreDuringBuilds` from Next.js config so builds fail on lint errors
- add CI workflow running `npm run lint` and `next build`
- fix TypeScript `any` usage to satisfy lint rules

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689bd0b8d9f4832185cf774eb3438b7f