### PR TITLE
Remove suggestion comments from geocode route

### DIFF
--- a/src/app/api/geocode/route.ts
+++ b/src/app/api/geocode/route.ts
@@ -1,6 +1,5 @@
 import { NextResponse } from 'next/server';
 
-// Suggestion 5: Add TypeScript interface for response type
 // This defines the shape of the data returned by OpenWeatherMap's geocoding API,
 // ensuring the code knows what to expect (e.g., city name, coordinates).
 interface GeocodeResponse {
@@ -22,7 +21,6 @@ export async function GET(request: Request) {
     return NextResponse.json({ message: 'Latitude and longitude are required' }, { status: 400 });
   }
 
-  // Suggestion 2: Validate lat and lon values
   // This checks if lat/lon are valid numbers and within correct ranges
   // (lat: -90 to 90, lon: -180 to 180) to prevent invalid API calls.
   const latNum = parseFloat(lat);
@@ -31,11 +29,9 @@ export async function GET(request: Request) {
     return NextResponse.json({ message: 'Invalid latitude or longitude' }, { status: 400 });
   }
 
-  // Suggestion 1: Switch to HTTPS
   // Changed 'http' to 'https' for secure communication to protect the API key.
   const url = `https://api.openweathermap.org/geo/1.0/reverse?lat=${latNum}&lon=${lonNum}&limit=1&appid=${apiKey}`;
 
-  // Suggestion 4: Add fetch timeout
   // This ensures the fetch doesn't hang if the API is slow, timing out after 5 seconds.
   const controller = new AbortController();
   const timeoutId = setTimeout(() => controller.abort(), 5000); // 5s timeout
@@ -44,7 +40,6 @@ export async function GET(request: Request) {
     const response = await fetch(url, { signal: controller.signal });
     clearTimeout(timeoutId); // Clear timeout if fetch succeeds
 
-    // Suggestion 3: Improve error handling
     // This safely handles JSON parsing and provides detailed error messages.
     let data;
     try {
@@ -55,14 +50,12 @@ export async function GET(request: Request) {
     }
 
     if (response.ok && data.length > 0) {
-      // Suggestion 5: Use typed response
       // Return data with TypeScript type for clarity and safety.
       return NextResponse.json<GeocodeResponse>(data[0]);
     } else {
       return NextResponse.json({ message: data.message || 'City not found' }, { status: 404 });
     }
   } catch (error) {
-    // Suggestion 3: Log and include error details
     // This helps debug issues by logging the error and sending its message to the client.
     console.error('Geocode fetch error:', error);
     const details = error instanceof Error ? error.message : String(error);


### PR DESCRIPTION
## Summary
- Strip "Suggestion x" prefixes from geocode API route comments
- Preserve meaningful explanations for response typing, coordinate validation, HTTPS usage, timeouts, and error logging

## Testing
- `npm test` *(missing script: "test")*
- `npm run lint` *(fails: Unexpected any in src/app/page.tsx)*

------
https://chatgpt.com/codex/tasks/task_e_689bd0c92ea88321bc412b53186ebcbf