### PR TITLE
Fix South Dakota name mapping

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -220,7 +220,7 @@ const US_STATE_ABBR_TO_NAME: Record<string, string> = {
   MT: "Montana", NE: "Nebraska", NV: "Nevada", NH: "New Hampshire", NJ: "New Jersey",
   NM: "New Mexico", NY: "New York", NC: "North Carolina", ND: "North Dakota", OH: "Ohio",
   OK: "Oklahoma", OR: "Oregon", PA: "Pennsylvania", RI: "Rhode Island", SC: "South Carolina",
-  SD: "South Carolina", TN: "Tennessee", TX: "Texas", UT: "Utah", VT: "Vermont",
+  SD: "South Dakota", TN: "Tennessee", TX: "Texas", UT: "Utah", VT: "Vermont",
   VA: "Virginia", WA: "Washington", WV: "West Virginia", WI: "Wisconsin", WY: "Wyoming",
   DC: "District of Columbia", PR: "Puerto Rico",
 };


### PR DESCRIPTION
## Summary
- fix SD state name in abbreviation-to-name map

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: Unexpected any. Specify a different type.)*

------
https://chatgpt.com/codex/tasks/task_e_689bd0cde5d483218e6d06c607bcb4be