### PR TITLE
chore: remove debug log from OneCall API

### DIFF
--- a/src/app/api/onecall/route.ts
+++ b/src/app/api/onecall/route.ts
@@ -42,7 +42,6 @@ export async function GET(request: Request) {
       console.error('OneCall response is not JSON:', contentType);
       return NextResponse.json({ message: 'Invalid API response' }, { status: 500 });
     }
-    console.log('OneCall response status:', response.status);
     const data = await response.json();
     if (response.ok) {
       return NextResponse.json<OneCallResponse>(data);


### PR DESCRIPTION
## Summary
- remove debug console log in OneCall API route

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Unexpected any. Specify a different type.)*

------
https://chatgpt.com/codex/tasks/task_e_689bd0d79e7083218bb0858eae2a78e9