### PR TITLE
Ensure OpenWeather API key is set before calls

### DIFF
--- a/src/app/api/geocode/route.ts
+++ b/src/app/api/geocode/route.ts
@@ -11,10 +11,17 @@ interface GeocodeResponse {
 }
 
 export async function GET(request: Request) {
+  const apiKey = process.env.OPENWEATHER_API_KEY;
+  if (!apiKey) {
+    return NextResponse.json(
+      { message: 'API key not configured' },
+      { status: 500 }
+    );
+  }
+
   const { searchParams } = new URL(request.url);
   const lat = searchParams.get('lat');
   const lon = searchParams.get('lon');
-  const apiKey = process.env.OPENWEATHER_API_KEY;
 
   // Existing validation for missing lat/lon
   if (!lat || !lon) {

--- a/src/app/api/onecall/route.ts
+++ b/src/app/api/onecall/route.ts
@@ -11,11 +11,18 @@ interface OneCallResponse {
 }
 
 export async function GET(request: Request) {
+  const apiKey = process.env.OPENWEATHER_API_KEY;
+  if (!apiKey) {
+    return NextResponse.json(
+      { message: 'API key not configured' },
+      { status: 500 }
+    );
+  }
+
   const { searchParams } = new URL(request.url);
   const lat = searchParams.get('lat');
   const lon = searchParams.get('lon');
   const unit = searchParams.get('unit') || 'imperial'; // Default to imperial
-  const apiKey = process.env.OPENWEATHER_API_KEY;
 
   if (!lat || !lon) {
     return NextResponse.json({ message: 'Latitude and longitude are required' }, { status: 400 });


### PR DESCRIPTION
## Summary
- fail early with 500 when `OPENWEATHER_API_KEY` is missing in geocode and onecall routes

## Testing
- `npm run test:run`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689be9734230832199bfaf9340c79a5d