### PR TITLE
Validate unit parameter in weather route

### DIFF
--- a/src/app/api/weather/route.ts
+++ b/src/app/api/weather/route.ts
@@ -10,6 +10,10 @@ export async function GET(request: Request) {
     const lat = searchParams.get("lat");
     const lon = searchParams.get("lon");
     const unit = searchParams.get("unit") || "imperial";
+    const validUnits = ["imperial", "metric", "standard"];
+    if (!validUnits.includes(unit)) {
+      return NextResponse.json({ message: "Invalid unit" }, { status: 400 });
+    }
 
     // If we don't have lat or lon, return an error
     if (!lat || !lon) {


### PR DESCRIPTION
## Summary
- validate unit query param in weather API to accept only `imperial`, `metric`, or `standard`
- return a 400 response for invalid units

## Testing
- `npm run test:run`


------
https://chatgpt.com/codex/tasks/task_e_689bec71af688321b1332fe83319734c