### PR TITLE
docs: add example env file and update setup instructions

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,2 @@
+# Copy this file to .env and fill in your credentials
+OPENWEATHER_API_KEY=your_openweather_api_key

--- a/README.md
+++ b/README.md
@@ -2,7 +2,14 @@ This is a [Next.js](https://nextjs.org) project bootstrapped with [`create-next-
 
 ## Getting Started
 
-First, run the development server:
+First, copy `.env.example` to `.env` and set the required environment variables:
+
+```bash
+cp .env.example .env
+# update OPENWEATHER_API_KEY with your OpenWeather credentials
+```
+
+Then, run the development server:
 
 ```bash
 npm run dev


### PR DESCRIPTION
## Summary
- add `.env.example` with `OPENWEATHER_API_KEY`
- document environment setup in README

## Testing
- `npm run test:run`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689bf4726ce883219b09917dfe2bb0d9