### PR TITLE
feat: add caching for OpenWeather responses

### DIFF
--- a/src/lib/openWeather.ts
+++ b/src/lib/openWeather.ts
@@ -4,6 +4,32 @@ type Endpoint = 'weather' | 'forecast';
 
 const validUnits = ['metric', 'imperial', 'standard'];
 
+// Cache configuration
+const TEN_MINUTES = 10 * 60 * 1000;
+
+interface CacheEntry<T> {
+  data: T;
+  expires: number;
+}
+
+// In-memory caches for geocode and weather/forecast responses
+const geocodeCache = new Map<string, CacheEntry<{ lat: number; lon: number }>>();
+const forecastCache = new Map<string, CacheEntry<unknown>>();
+
+function getCacheEntry<T>(cache: Map<string, CacheEntry<T>>, key: string): T | undefined {
+  const entry = cache.get(key);
+  if (entry && entry.expires > Date.now()) {
+    return entry.data;
+  }
+  cache.delete(key);
+  return undefined;
+}
+
+export function clearCaches() {
+  geocodeCache.clear();
+  forecastCache.clear();
+}
+
 export async function openWeather(endpoint: Endpoint, request: Request) {
   const { searchParams } = new URL(request.url);
   const city = searchParams.get('city');
@@ -20,38 +46,46 @@ export async function openWeather(endpoint: Endpoint, request: Request) {
 
   const validatedUnit = validUnits.includes(unit) ? unit : 'imperial';
 
-  const geoUrl = `https://api.openweathermap.org/geo/1.0/direct?q=${city}&limit=1&appid=${apiKey}`;
-  let lat: number;
-  let lon: number;
-
-  try {
-    const geoResponse = await fetch(geoUrl, { signal: AbortSignal.timeout(5000) });
-    const geoData = await geoResponse.json();
-    if (!geoResponse.ok) {
-      return NextResponse.json(
-        { message: geoData.message || 'City not found' },
-        { status: geoResponse.status }
-      );
-    }
-    if (geoData.length === 0) {
-      return NextResponse.json({ message: 'City not found' }, { status: 404 });
-    }
-    lat = geoData[0].lat;
-    lon = geoData[0].lon;
-  } catch (error) {
-    console.error('Geocoding error:', error);
-    return NextResponse.json(
-      { message: 'Failed to geocode city', details: (error as Error).message },
-      { status: 500 }
-    );
+  const forecastKey = `${endpoint}:${city.toLowerCase()}:${validatedUnit}`;
+  const cachedForecast = getCacheEntry(forecastCache, forecastKey);
+  if (cachedForecast) {
+    return NextResponse.json(cachedForecast);
   }
 
-  const url = `https://api.openweathermap.org/data/2.5/${endpoint}?lat=${lat}&lon=${lon}&appid=${apiKey}&units=${validatedUnit}`;
+  const geoKey = city.toLowerCase();
+  let coords = getCacheEntry(geocodeCache, geoKey);
+  if (!coords) {
+    const geoUrl = `https://api.openweathermap.org/geo/1.0/direct?q=${city}&limit=1&appid=${apiKey}`;
+    try {
+      const geoResponse = await fetch(geoUrl, { signal: AbortSignal.timeout(5000) });
+      const geoData = await geoResponse.json();
+      if (!geoResponse.ok) {
+        return NextResponse.json(
+          { message: geoData.message || 'City not found' },
+          { status: geoResponse.status }
+        );
+      }
+      if (geoData.length === 0) {
+        return NextResponse.json({ message: 'City not found' }, { status: 404 });
+      }
+      coords = { lat: geoData[0].lat, lon: geoData[0].lon };
+      geocodeCache.set(geoKey, { data: coords, expires: Date.now() + TEN_MINUTES });
+    } catch (error) {
+      console.error('Geocoding error:', error);
+      return NextResponse.json(
+        { message: 'Failed to geocode city', details: (error as Error).message },
+        { status: 500 }
+      );
+    }
+  }
+
+  const url = `https://api.openweathermap.org/data/2.5/${endpoint}?lat=${coords.lat}&lon=${coords.lon}&appid=${apiKey}&units=${validatedUnit}`;
 
   try {
     const response = await fetch(url, { signal: AbortSignal.timeout(5000) });
     const data = await response.json();
     if (response.ok) {
+      forecastCache.set(forecastKey, { data, expires: Date.now() + TEN_MINUTES });
       return NextResponse.json(data);
     } else {
       return NextResponse.json(


### PR DESCRIPTION
## Summary
- add 10-minute in-memory cache for geocode and forecast data
- cover cache behavior with unit tests

## Testing
- `npm run lint`
- `npm run test:run`


------
https://chatgpt.com/codex/tasks/task_e_689bfd25b0c083219f71dd3e254a03bd