### PR TITLE
Add timeout handling to upstream weather fetches

### DIFF
--- a/src/app/api/weather/route.ts
+++ b/src/app/api/weather/route.ts
@@ -38,8 +38,17 @@ export async function GET(request: Request) {
     });
   } catch (error) {
     console.error("Error in weather API route:", error);
+    if (error instanceof Error && error.name === "AbortError") {
+      return NextResponse.json(
+        { error: "Upstream request timed out" },
+        { status: 504 }
+      );
+    }
     // If anything goes wrong, send a generic server error response
-    return NextResponse.json({ error: "Failed to fetch weather data" }, { status: 500 });
+    return NextResponse.json(
+      { error: "Failed to fetch weather data" },
+      { status: 500 }
+    );
   }
 }
 
@@ -64,7 +73,7 @@ async function fetchForecast(lat: string, lon: string, unit: string) {
   });
 
   const url = `https://api.open-meteo.com/v1/forecast?${params.toString()}`;
-  const res = await fetch(url);
+  const res = await fetch(url, { signal: AbortSignal.timeout(5000) });
 
   if (!res.ok) {
     throw new Error("Failed to fetch forecast data from Open-Meteo");
@@ -77,7 +86,10 @@ async function fetchForecast(lat: string, lon: string, unit: string) {
 async function fetchAlerts(lat: string, lon: string) {
   try {
     const url = `https://api.weather.gov/alerts/active?point=${lat},${lon}`;
-    const res = await fetch(url, { headers: { Accept: "application/geo+json" } });
+    const res = await fetch(url, {
+      headers: { Accept: "application/geo+json" },
+      signal: AbortSignal.timeout(5000),
+    });
 
     if (!res.ok) {
       console.warn("Could not fetch alerts from weather.gov");
@@ -88,6 +100,9 @@ async function fetchAlerts(lat: string, lon: string) {
     // We only need the 'features' array from the response
     return Array.isArray(data?.features) ? data.features : [];
   } catch (error) {
+    if (error instanceof Error && error.name === "AbortError") {
+      throw error;
+    }
     console.warn("Error fetching alerts:", error);
     return []; // Return empty array on any error
   }


### PR DESCRIPTION
## Summary
- cancel upstream forecast and alert requests after 5s
- return 504 JSON response when upstream request times out

## Testing
- `npm test -- --run`


------
https://chatgpt.com/codex/tasks/task_e_689bffaa59808321acb3ae58d4239084