### PR TITLE
Enable geolocation in embedded map

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -399,6 +399,7 @@ function MapPanel({ coords, unit, className }: { coords: Coords; unit: Unit; cla
       className="h-full w-full rounded-xl border border-white/10 shadow-xl"
       loading="lazy"
       referrerPolicy="no-referrer-when-downgrade"
+      allow="geolocation"
     />
   );
 
@@ -447,6 +448,7 @@ function MapPanel({ coords, unit, className }: { coords: Coords; unit: Unit; cla
                 className="h-full w-full"
                 loading="lazy"
                 referrerPolicy="no-referrer-when-downgrade"
+                allow="geolocation"
               />
             </div>
           </div>


### PR DESCRIPTION
## Summary
- allow Windy map iframes to request geolocation so the user's position is shown correctly

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689c0ef351b083219d38fe5caa6d1df5