### PR TITLE
Add JavaScript Next.js config for deployment

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,3 +42,7 @@ The app will be available at [http://localhost:3000](http://localhost:3000).
 ```bash
 npm test
 ```
+
+## Deployment
+
+Some hosting providers do not yet support loading a `next.config.ts` file. If your deployment platform requires a JavaScript configuration, use the provided `next.config.mjs` which exports the same settings as the TypeScript file.

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -1,0 +1,7 @@
+/** @type {import('next').NextConfig} */
+const nextConfig = {
+  images: {
+    domains: ['openweathermap.org'], // Allow images from this domain
+  },
+};
+export default nextConfig;


### PR DESCRIPTION
## Summary
- add `next.config.mjs` mirroring the TypeScript config for hosts that don't load TS configs
- document using the JS config in deployment environments that don't support `next.config.ts`

## Testing
- `npm run test:run`

------
https://chatgpt.com/codex/tasks/task_e_689fcf84326c83218ecf024f78cc186f